### PR TITLE
fix: Override nix-update filename

### DIFF
--- a/nix-update.sh
+++ b/nix-update.sh
@@ -31,11 +31,11 @@ updatePackages() {
     fi
     echo "Updating package '${PACKAGE}'."
     if [[ ",${UNSTABLE}," == *",${PACKAGE},"* ]]; then
-      nix-update --flake --commit "${PACKAGE}" --version=unstable 1>/dev/null
+      nix-update --flake --commit "${PACKAGE}" --version=unstable --override-filename "./packages/${PACKAGE}/default.nix" 1>/dev/null
     elif [[ ",${FROM_BRANCH}," == *",${PACKAGE},"* ]]; then
-      nix-update --flake --commit "${PACKAGE}" --version=branch 1>/dev/null
+      nix-update --flake --commit "${PACKAGE}" --version=branch --override-filename "./packages/${PACKAGE}/default.nix" 1>/dev/null
     else
-      nix-update --flake --commit "${PACKAGE}" 1>/dev/null
+      nix-update --flake --commit "${PACKAGE}" --override-filename "./packages/${PACKAGE}/default.nix" 1>/dev/null
     fi
   done
 }


### PR DESCRIPTION
In certain packages, the default process does not find the correct nix source file. We'll manually specify it, with the assumption that we're properly organizing our packages.

After this is merged, I'll open a PR in nix-blockchain-development which fixes the auto-update CI.